### PR TITLE
fix: php notice getting first entry of collection

### DIFF
--- a/Smarty/Plugins/BetterSeoMicroDataPlugin.php
+++ b/Smarty/Plugins/BetterSeoMicroDataPlugin.php
@@ -151,7 +151,7 @@ class BetterSeoMicroDataPlugin extends AbstractSmartyPlugin
     protected function getProductMicroData(Product $product, Lang $lang, $relatedProducts = [])
     {
         $product->setLocale($lang->getLocale());
-        $image = ProductImageQuery::create()->filterByProductId($product->getId())->orderByPosition()->find()[0];
+        $image = ProductImageQuery::create()->filterByProductId($product->getId())->orderByPosition()->find()->getFirst();
         $pse = ProductSaleElementsQuery::create()->filterByProductId($product->getId())->filterByIsDefault(1)->findOne();
         $psePrice = ProductPriceQuery::create()->filterByProductSaleElementsId($pse->getId())->findOne();
         $taxCountry = $this->taxEngine->getDeliveryCountry();


### PR DESCRIPTION
Fix accessing the first entry of a collection.
With php 8.2 I was getting the error : `Notice: Only variable references should be returned by reference`.